### PR TITLE
Fix NPE when showing an error state that doesn't contain a retry button in its layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.0-RC01] - 07/04/2020
+- First release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fix NPE when showing an error state that doesn't contain a retry button in its layout
 
 ## [1.0-RC01] - 07/04/2020
 - First release

--- a/lib/src/main/ktx/com/fabernovel/statefullayout/StatefulLayout.kt
+++ b/lib/src/main/ktx/com/fabernovel/statefullayout/StatefulLayout.kt
@@ -26,9 +26,17 @@ fun StatefulLayout.getStateView(@IdRes key: Int): View {
     return this[key].contentView
 }
 
-fun StatefulLayout.showError(onRetryListener: (View) -> Unit = {}): State {
+fun StatefulLayout.showError(onRetryListener: ((View) -> Unit)? = null): State {
     val errorState = showState(R.id.stateError)
-    errorState.findViewById<Button>(R.id.stateErrorRetryButton).setOnClickListener(onRetryListener)
+    if (onRetryListener != null) {
+        val retryButton = errorState.findViewById<Button>(R.id.stateErrorRetryButton)
+        requireNotNull(retryButton) {
+            "The layout associated to the state 'stateError' must contain a Button with the id " +
+            "'stateErrorRetryButton'"
+        }
+
+        retryButton.setOnClickListener(onRetryListener)
+    }
     return errorState
 }
 


### PR DESCRIPTION
This allows to use the `showError()` extension on a custom layout that doesn't have a retry button