### PR TITLE
Add two fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Breaking change
 - Fix typo on xml attribute `defaultExitrTransition` that has been renamed to `defaultExitTransition`
+### Fixed
+- Fix enter/exit defaultTransition sharing the same animation instance for all the states. Switching
+quickly between states was resulting in animation issue.
 
 ## [1.0-RC03]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fix enter/exit defaultTransition sharing the same animation instance for all the states. Switching
 quickly between states was resulting in animation issue.
+- Fix crash when restoring a StatefulLayout that has no state
 
 ## [1.0-RC03]
 ### Added

--- a/lib/src/main/java/com/fabernovel/statefullayout/State.kt
+++ b/lib/src/main/java/com/fabernovel/statefullayout/State.kt
@@ -8,6 +8,7 @@ import android.widget.FrameLayout
 import androidx.annotation.LayoutRes
 import com.fabernovel.statefullayout.transitions.StateTransition
 import com.fabernovel.statefullayout.transitions.StateTransitionListener
+import com.fabernovel.statefullayout.transitions.StateTransitionProvider
 import com.fabernovel.statefullayout.transitions.StateTransitions
 
 /**
@@ -111,9 +112,9 @@ class State : FrameLayout {
         }
     }
 
-    internal fun show(fallbackTransition: StateTransition? = null) {
+    internal fun show(fallbackTransitionProvider: StateTransitionProvider? = null) {
         currentTransition?.cancel()
-        val transition = enterTransition ?: fallbackTransition
+        val transition = enterTransition ?: fallbackTransitionProvider?.get()
         if (transition == null) {
             visibility = View.VISIBLE
         } else {
@@ -126,9 +127,9 @@ class State : FrameLayout {
         }
     }
 
-    internal fun hide(fallbackTransition: StateTransition? = null) {
+    internal fun hide(fallbackTransitionProvider: StateTransitionProvider? = null) {
         currentTransition?.cancel()
-        val transition = exitTransition ?: fallbackTransition
+        val transition = exitTransition ?: fallbackTransitionProvider?.get()
         if (transition == null) {
             visibility = View.GONE
         } else {

--- a/lib/src/main/java/com/fabernovel/statefullayout/StatefulLayout.kt
+++ b/lib/src/main/java/com/fabernovel/statefullayout/StatefulLayout.kt
@@ -12,6 +12,7 @@ import androidx.annotation.IdRes
 import androidx.annotation.StyleRes
 import androidx.core.view.isVisible
 import com.fabernovel.statefullayout.transitions.StateTransition
+import com.fabernovel.statefullayout.transitions.StateTransitionProvider
 import com.fabernovel.statefullayout.transitions.StateTransitions
 
 /**
@@ -29,12 +30,12 @@ class StatefulLayout : FrameLayout, StateContainer<Int, State> {
     /**
      *  [StateTransition] played when any state is displayed
      */
-    var defaultEnterTransition: StateTransition? = null
+    var defaultEnterTransition: StateTransitionProvider? = null
 
     /**
      * [StateTransition] played when any state is hidden
      */
-    var defaultExitTransition: StateTransition? = null
+    var defaultExitTransition: StateTransitionProvider? = null
 
     constructor(context: Context) : this(context, null)
 
@@ -94,14 +95,22 @@ class StatefulLayout : FrameLayout, StateContainer<Int, State> {
             0
         )
         if (defaultEnterAnimRes != 0) {
-            defaultEnterTransition = StateTransitions.fromResource(context, defaultEnterAnimRes)
+            defaultEnterTransition = createTransitionProviderOf(defaultEnterAnimRes)
         }
         val defaultExitAnimRes = array.getResourceId(
             R.styleable.StatefulLayout_defaultExitTransition,
             0
         )
         if (defaultExitAnimRes != 0) {
-            defaultExitTransition = StateTransitions.fromResource(context, defaultExitAnimRes)
+            defaultExitTransition = createTransitionProviderOf(defaultExitAnimRes)
+        }
+    }
+
+    private fun createTransitionProviderOf(animRes: Int): StateTransitionProvider {
+        return object : StateTransitionProvider {
+            override fun get(): StateTransition {
+                return StateTransitions.fromResource(context, animRes)
+            }
         }
     }
 

--- a/lib/src/main/java/com/fabernovel/statefullayout/StatefulLayout.kt
+++ b/lib/src/main/java/com/fabernovel/statefullayout/StatefulLayout.kt
@@ -166,7 +166,9 @@ class StatefulLayout : FrameLayout, StateContainer<Int, State> {
         super.onRestoreInstanceState(state?.superState)
 
         if (savedState != null) {
-            showState(savedState.currentStateId)
+            if (savedState.currentStateId != View.NO_ID) {
+                showState(savedState.currentStateId)
+            }
         }
     }
 
@@ -219,7 +221,7 @@ class StatefulLayout : FrameLayout, StateContainer<Int, State> {
     }
 
     private class SavedState : BaseSavedState {
-        var currentStateId: Int = -1
+        var currentStateId: Int = View.NO_ID
 
         constructor(superState: Parcelable?) : super(superState)
 

--- a/lib/src/main/java/com/fabernovel/statefullayout/transitions/StateTransitionProvider.kt
+++ b/lib/src/main/java/com/fabernovel/statefullayout/transitions/StateTransitionProvider.kt
@@ -1,0 +1,5 @@
+package com.fabernovel.statefullayout.transitions
+
+interface StateTransitionProvider {
+    fun get(): StateTransition
+}


### PR DESCRIPTION
* Fix enter/exit defaultTransition sharing the same animation instance for all the states. Switching quickly between states was resulting in animation issue.
* Fix crash when restoring a StatefulLayout that has no state