### PR TITLE
Add a boolean to disabled state transition

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 on: pull_request
 jobs:
   build_and_check:
-    name: 🛠 Build and check
+    name: Build and check
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -16,7 +16,7 @@ jobs:
           gem install bundler
           bundle install
   danger:
-    name: 🚧 Danger
+    name: Danger
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add units tests in the sample app
 - Run Danger to validate PR
 - Add a contribution guide
-- Add `showState(@IdRes id: Int, playTransition: Boolean)` to StatefulLayout to disable transition
+- Add `showState(@IdRes id: Int, showTransitions: Boolean)` to StatefulLayout to disable transition
 - Stateful layouts now have a `areTransitionsEnabled` attribute to enable/disable transitions
 
 ## [1.0-RC4] - 27/04/2020

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Run Danger to validate PR
 - Add a contribution guide
 - Add `showState(@IdRes id: Int, playTransition: Boolean)` to StatefulLayout to disable transition
+- Stateful layouts now have a `areTransitionsEnabled` attribute to enable/disable transitions
 
 ## [1.0-RC4] - 27/04/2020
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add units tests in the sample app
 - Run Danger to validate PR
 - Add a contribution guide
+- Add `showState(@IdRes id: Int, playTransition: Boolean)` to StatefulLayout to disable transition
 
 ## [1.0-RC4] - 27/04/2020
 ### Changed

--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ errorBinding.stateErrorRetryButton.setOnClickListener {
 | initialState  | Id of the initially displayed state. (by default: none)  |
 | defaultEnterTransition  | Default enter transition. (by default: none)  |
 | defaultExitTransition  | Default exit transition. (by default: none)  |
+| areTransitionsEnabled | Play transitions when changing state (by default: true) |
 
 `State` also have an theme attribute `stateStyle` and a default style `Widget.Stateful.State`
 | Attribute  | Definition |

--- a/lib/src/main/java/com/fabernovel/statefullayout/State.kt
+++ b/lib/src/main/java/com/fabernovel/statefullayout/State.kt
@@ -112,10 +112,13 @@ class State : FrameLayout {
         }
     }
 
-    internal fun show(fallbackTransitionProvider: StateTransitionProvider? = null) {
+    internal fun show(
+        fallbackTransitionProvider: StateTransitionProvider? = null,
+        playTransition: Boolean = true
+    ) {
         currentTransition?.cancel()
         val transition = enterTransition ?: fallbackTransitionProvider?.get()
-        if (transition == null) {
+        if (transition == null || !playTransition) {
             visibility = View.VISIBLE
         } else {
             currentTransition = transition
@@ -127,10 +130,13 @@ class State : FrameLayout {
         }
     }
 
-    internal fun hide(fallbackTransitionProvider: StateTransitionProvider? = null) {
+    internal fun hide(
+        fallbackTransitionProvider: StateTransitionProvider? = null,
+        playTransition: Boolean = true
+    ) {
         currentTransition?.cancel()
         val transition = exitTransition ?: fallbackTransitionProvider?.get()
-        if (transition == null) {
+        if (transition == null || !playTransition) {
             visibility = View.GONE
         } else {
             currentTransition = transition

--- a/lib/src/main/java/com/fabernovel/statefullayout/StatefulLayout.kt
+++ b/lib/src/main/java/com/fabernovel/statefullayout/StatefulLayout.kt
@@ -181,17 +181,28 @@ class StatefulLayout : FrameLayout, StateContainer<Int, State> {
      * @throws [NoSuchElementException] if [id] was not found.
      */
     override fun showState(@IdRes id: Int): State {
+        return showState(id, true)
+    }
+
+    /**
+     * Show a state
+     *
+     * @param id
+     * @param playTransition if true, the transition will be played
+     * @return
+     */
+    fun showState(@IdRes id: Int, playTransition: Boolean): State {
         if (currentStateId != View.NO_ID) {
             val currentState = get(currentStateId)
             if (id == currentStateId) {
                 return currentState
             }
-            currentState.hide(defaultExitTransition)
+            currentState.hide(defaultExitTransition, playTransition)
         }
 
         val nextState = states[id]
             ?: throw NoSuchElementException("$id was not found in this StatefulLayout.")
-        nextState.show(defaultEnterTransition)
+        nextState.show(defaultEnterTransition, playTransition)
 
         _currentStateId = id
         return nextState

--- a/lib/src/main/java/com/fabernovel/statefullayout/StatefulLayout.kt
+++ b/lib/src/main/java/com/fabernovel/statefullayout/StatefulLayout.kt
@@ -37,6 +37,11 @@ class StatefulLayout : FrameLayout, StateContainer<Int, State> {
      */
     var defaultExitTransition: StateTransitionProvider? = null
 
+    /**
+     * If disable no [StateTransition] will be played
+     */
+    var areTransitionsEnabled: Boolean = true
+
     constructor(context: Context) : this(context, null)
 
     constructor(context: Context, attrs: AttributeSet?) : this(
@@ -78,7 +83,7 @@ class StatefulLayout : FrameLayout, StateContainer<Int, State> {
             inflateLoadingState(array)
             inflateErrorState(array)
 
-            loadDefaultAnimations(array)
+            loadDefaultTransitions(array)
 
             initialStateId = array.getResourceId(
                 R.styleable.StatefulLayout_initialState,
@@ -89,7 +94,13 @@ class StatefulLayout : FrameLayout, StateContainer<Int, State> {
         }
     }
 
-    private fun loadDefaultAnimations(array: TypedArray) {
+    private fun loadDefaultTransitions(array: TypedArray) {
+        val areTransitionsEnabled = array.getBoolean(
+            R.styleable.StatefulLayout_areTransitionsEnabled,
+            true
+        )
+        this.areTransitionsEnabled = areTransitionsEnabled
+
         val defaultEnterAnimRes = array.getResourceId(
             R.styleable.StatefulLayout_defaultEnterTransition,
             0
@@ -181,28 +192,28 @@ class StatefulLayout : FrameLayout, StateContainer<Int, State> {
      * @throws [NoSuchElementException] if [id] was not found.
      */
     override fun showState(@IdRes id: Int): State {
-        return showState(id, true)
+        return showState(id, areTransitionsEnabled)
     }
 
     /**
      * Show a state
      *
      * @param id
-     * @param playTransition if true, the transition will be played
+     * @param areTransitionEnabled if true, the transition will be played
      * @return
      */
-    fun showState(@IdRes id: Int, playTransition: Boolean): State {
+    fun showState(@IdRes id: Int, areTransitionEnabled: Boolean): State {
         if (currentStateId != View.NO_ID) {
             val currentState = get(currentStateId)
             if (id == currentStateId) {
                 return currentState
             }
-            currentState.hide(defaultExitTransition, playTransition)
+            currentState.hide(defaultExitTransition, areTransitionEnabled)
         }
 
         val nextState = states[id]
             ?: throw NoSuchElementException("$id was not found in this StatefulLayout.")
-        nextState.show(defaultEnterTransition, playTransition)
+        nextState.show(defaultEnterTransition, areTransitionEnabled)
 
         _currentStateId = id
         return nextState

--- a/lib/src/main/java/com/fabernovel/statefullayout/StatefulLayout.kt
+++ b/lib/src/main/java/com/fabernovel/statefullayout/StatefulLayout.kt
@@ -38,7 +38,7 @@ class StatefulLayout : FrameLayout, StateContainer<Int, State> {
     var defaultExitTransition: StateTransitionProvider? = null
 
     /**
-     * If disable no [StateTransition] will be played
+     * If disabled no [StateTransition] will be played
      */
     var areTransitionsEnabled: Boolean = true
 
@@ -185,7 +185,10 @@ class StatefulLayout : FrameLayout, StateContainer<Int, State> {
     }
 
     /**
-     * Show a state
+     * Show a state.
+     *
+     * Note:
+     *  If [areTransitionsEnabled] is disabled, no transition will be played.
      *
      * @param id state's id
      * @return shown state
@@ -196,24 +199,25 @@ class StatefulLayout : FrameLayout, StateContainer<Int, State> {
     }
 
     /**
-     * Show a state
+     * Show a state.
      *
      * @param id
-     * @param areTransitionEnabled if true, the transition will be played
+     * @param showTransitions if true, the transition will be played
+     *  (overrides [areTransitionsEnabled])
      * @return
      */
-    fun showState(@IdRes id: Int, areTransitionEnabled: Boolean): State {
+    fun showState(@IdRes id: Int, showTransitions: Boolean): State {
         if (currentStateId != View.NO_ID) {
             val currentState = get(currentStateId)
             if (id == currentStateId) {
                 return currentState
             }
-            currentState.hide(defaultExitTransition, areTransitionEnabled)
+            currentState.hide(defaultExitTransition, showTransitions)
         }
 
         val nextState = states[id]
             ?: throw NoSuchElementException("$id was not found in this StatefulLayout.")
-        nextState.show(defaultEnterTransition, areTransitionEnabled)
+        nextState.show(defaultEnterTransition, showTransitions)
 
         _currentStateId = id
         return nextState

--- a/lib/src/main/res-public/values/public.xml
+++ b/lib/src/main/res-public/values/public.xml
@@ -9,6 +9,7 @@
     <!-- StatefulLayout style attributes -->
     <public type="style" name="Widget.Stateful.StatefulLayout"/>
     <public type="attr" name="statefulLayoutStyle" />
+    <public type="attr" name="areTransitionsEnabled" />
     <public type="attr" name="loadingStateLayout"/>
     <public type="attr" name="errorStateLayout"/>
     <public type="attr" name="initialState"/>

--- a/lib/src/main/res/values/styleables.xml
+++ b/lib/src/main/res/values/styleables.xml
@@ -6,6 +6,7 @@
         <attr name="initialState" format="reference"/>
         <attr name="defaultEnterTransition" format="reference"/>
         <attr name="defaultExitTransition" format="reference"/>
+        <attr name="areTransitionsEnabled" format="boolean"/>
     </declare-styleable>
 
     <declare-styleable name="State">

--- a/lib/src/main/res/values/styles.xml
+++ b/lib/src/main/res/values/styles.xml
@@ -4,6 +4,7 @@
         parent="">
         <item name="loadingStateLayout">@layout/state_loading</item>
         <item name="errorStateLayout">@layout/state_error</item>
+        <item name="areTransitionsEnabled">true</item>
     </style>
 
     <style name="Widget.Stateful.State"


### PR DESCRIPTION
When switching from a state to another, you can use `showState(<id>, false)` to prevent the state transition. 