### PR TITLE
Remove state duplicates in view hierarchy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,15 +5,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-## Changed
+### Changed
 - Upgrade Android Gradle Plugin to 3.6.3
 - Upgrade Kotlin to 1.3.72
-## Added
+### Added
 - Add units tests in the sample app
 - Run Danger to validate PR
 - Add a contribution guide
 - Add `showState(@IdRes id: Int, showTransitions: Boolean)` to StatefulLayout to disable transition
 - Stateful layouts now have a `areTransitionsEnabled` attribute to enable/disable transitions
+### Fixed
+- Remove duplicates in view hierarchy when trying to overload an existing state
 
 ## [1.0-RC4] - 27/04/2020
 ### Changed

--- a/lib/src/main/java/com/fabernovel/statefullayout/StatefulLayout.kt
+++ b/lib/src/main/java/com/fabernovel/statefullayout/StatefulLayout.kt
@@ -151,8 +151,16 @@ class StatefulLayout : FrameLayout, StateContainer<Int, State> {
         if (childId == View.NO_ID) {
             throw IllegalArgumentException("StatefulLayout states should have an id. ($child)")
         }
+        removeExistingStateView(childId)
         child.isVisible = childId == initialStateId
         states[childId] = child
+    }
+
+    private fun removeExistingStateView(@IdRes stateId: Int) {
+        val existingStateView = states[stateId]
+        if (existingStateView != null) {
+            removeView(existingStateView)
+        }
     }
 
     override fun onFinishInflate() {


### PR DESCRIPTION
Declaring two states with the same id was properly erasing the first declared state from the 'states' table of StatefulLayout, but it was not removing its view from the view hierarchy

On my project, I was overloading `stateError` and I had this crash because of the duplicate :
```
Wrong state class, expecting View State but received class com.google.android.material.button.MaterialButton$SavedState instead.
This usually happens when two views of different type have the same id in the same hierarchy. 
This view's id is id/stateErrorRetryButton. 
Make sure other views do not use the same id.
```