### PR TITLE
Remove state duplicates in view hierarchy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,15 +5,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-## Changed
+### Changed
 - Upgrade Android Gradle Plugin to 3.6.3
 - Upgrade Kotlin to 1.3.72
-## Added
+### Added
 - Add units tests in the sample app
 - Run Danger to validate PR
 - Add a contribution guide
 - Add `showState(@IdRes id: Int, showTransitions: Boolean)` to StatefulLayout to disable transition
 - Stateful layouts now have a `areTransitionsEnabled` attribute to enable/disable transitions
+### Fixed
+- Remove duplicates in view hierarchy when trying to overload an existing state
 
 ## [1.0-RC4] - 27/04/2020
 ### Changed

--- a/lib/src/main/java/com/fabernovel/statefullayout/StatefulLayout.kt
+++ b/lib/src/main/java/com/fabernovel/statefullayout/StatefulLayout.kt
@@ -151,8 +151,16 @@ class StatefulLayout : FrameLayout, StateContainer<Int, State> {
         if (childId == View.NO_ID) {
             throw IllegalArgumentException("StatefulLayout states should have an id. ($child)")
         }
+        removeExistingStateView(childId)
         child.isVisible = childId == initialStateId
         states[childId] = child
+    }
+
+    private fun removeExistingStateView(@IdRes stateId: Int) {
+        val existingStateView = states[stateId]
+        if (existingStateView != null) {
+            removeView(existingStateView)
+        }
     }
 
     override fun onFinishInflate() {

--- a/sample-app/src/main/java/com/fabernovel/statefullayout/sample/ui/override/OverrideDefaultFragment.kt
+++ b/sample-app/src/main/java/com/fabernovel/statefullayout/sample/ui/override/OverrideDefaultFragment.kt
@@ -1,0 +1,6 @@
+package com.fabernovel.statefullayout.sample.ui.override
+
+import androidx.fragment.app.Fragment
+import com.fabernovel.statefullayout.sample.R
+
+class OverrideDefaultFragment : Fragment(R.layout.override_default_fragment)

--- a/sample-app/src/main/res/layout/override_default_fragment.xml
+++ b/sample-app/src/main/res/layout/override_default_fragment.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.fabernovel.statefullayout.StatefulLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/stateful_layout"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    >
+
+    <com.fabernovel.statefullayout.State
+        android:id="@+id/stateLoading"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        >
+        <TextView
+            android:id="@+id/custom_loading_text"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:text="@string/custom_loading_state"
+            />
+    </com.fabernovel.statefullayout.State>
+
+    <com.fabernovel.statefullayout.State
+        android:id="@+id/stateError"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        >
+
+        <TextView
+            android:id="@+id/custom_error_text"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:text="@string/custom_error_state"
+            />
+    </com.fabernovel.statefullayout.State>
+</com.fabernovel.statefullayout.StatefulLayout>

--- a/sample-app/src/main/res/values/strings.xml
+++ b/sample-app/src/main/res/values/strings.xml
@@ -1,3 +1,5 @@
 <resources>
     <string name="app_name">sample-app</string>
+    <string name="custom_error_state">Custom error state</string>
+    <string name="custom_loading_state">Custom loading state</string>
 </resources>

--- a/sample-app/src/test/java/com/fabernovel/statefullayout/sample/ui/override/OverrideDefaultFragmentTest.kt
+++ b/sample-app/src/test/java/com/fabernovel/statefullayout/sample/ui/override/OverrideDefaultFragmentTest.kt
@@ -1,0 +1,22 @@
+package com.fabernovel.statefullayout.sample.ui.override
+
+import android.os.Build
+import com.fabernovel.statefullayout.sample.ui.empty.`on empty fragment`
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [Build.VERSION_CODES.P])
+class OverrideDefaultFragmentTest {
+
+    @Test
+    fun `given a stateful with only overridden defaults states, it should contains only two states`() {
+        `on override default fragment` {
+            containsOnlyOverrideDefaultStates()
+            hasOverriddenErrorState()
+            hasOverriddenLoadingState()
+        }
+    }
+}

--- a/sample-app/src/test/java/com/fabernovel/statefullayout/sample/ui/override/OverrideDefaultStateRobot.kt
+++ b/sample-app/src/test/java/com/fabernovel/statefullayout/sample/ui/override/OverrideDefaultStateRobot.kt
@@ -1,0 +1,40 @@
+package com.fabernovel.statefullayout.sample.ui.override
+
+import androidx.fragment.app.testing.FragmentScenario
+import androidx.test.espresso.matcher.ViewMatchers.hasDescendant
+import androidx.test.espresso.matcher.ViewMatchers.withId
+import com.fabernovel.statefullayout.sample.R
+import com.fabernovel.statefullayout.utils.containsState
+import com.fabernovel.statefullayout.utils.hasStateCount
+import com.fabernovel.statefullayout.utils.withStatefulLayoutStateId
+
+fun `on override default fragment`(func: OverrideDefaultRobot.() -> Unit) =
+    OverrideDefaultRobot().apply(func)
+
+class OverrideDefaultRobot {
+    init {
+        FragmentScenario.launchInContainer(OverrideDefaultFragment::class.java)
+    }
+
+    fun containsOnlyOverrideDefaultStates() {
+        hasStateCount(R.id.stateful_layout, 2)
+        containsState(
+            R.id.stateful_layout,
+            R.id.stateLoading
+        )
+        containsState(
+            R.id.stateful_layout,
+            R.id.stateError
+        )
+    }
+
+    fun hasOverriddenLoadingState() {
+        withStatefulLayoutStateId(R.id.stateLoading)
+            .matches(hasDescendant(withId(R.id.custom_error_text)))
+    }
+
+    fun hasOverriddenErrorState() {
+        withStatefulLayoutStateId(R.id.stateError)
+            .matches(hasDescendant(withId(R.id.custom_loading_text)))
+    }
+}


### PR DESCRIPTION
Duplicates #39 
Fixes #52

Declaring two states with the same id was properly erasing the first declared state from the 'states' table of StatefulLayout, but it was not removing its view from the view hierarchy

On my project, I was overloading stateError and I had this crash because of the duplicate :
```
Wrong state class, expecting View State but received class com.google.android.material.button.MaterialButton$SavedState instead.
This usually happens when two views of different type have the same id in the same hierarchy. 
This view's id is id/stateErrorRetryButton. 
Make sure other views do not use the same id.
```