### PR TITLE
Create StateChangeRegulator

### DIFF
--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -56,6 +56,7 @@ dependencies {
     implementation(kotlin("stdlib-jdk8", KotlinCompilerVersion.VERSION))
 
     implementation("androidx.appcompat", "appcompat", "1.1.0")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.8")
     implementation("androidx.constraintlayout", "constraintlayout", "1.1.3")
     implementation("androidx.core", "core-ktx", "1.2.0")
 

--- a/lib/src/main/java/com/fabernovel/statefullayout/StateChangeRegulator.kt
+++ b/lib/src/main/java/com/fabernovel/statefullayout/StateChangeRegulator.kt
@@ -1,0 +1,65 @@
+package com.fabernovel.statefullayout
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.channels.BroadcastChannel
+import kotlinx.coroutines.channels.ConflatedBroadcastChannel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.asFlow
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.flatMapConcat
+import kotlinx.coroutines.flow.flow
+import kotlin.time.Duration
+import kotlin.time.ExperimentalTime
+
+/**
+ * Responsible for regulating state-change requests.
+ *
+ * Use in conjunction with [StatefulLayout] for a "minimal duration by state"  behavior.
+ *
+ *
+ * Will make sure that once [start] is called, some or all requests passed to [requestStateChange]
+ * method will be forwarded to [requestHandler], respecting the minimal time between
+ * requests [minimalTimeBetweenRequests].
+ *
+ * If requests are chained (almost zero milliseconds in between) then all will be ignored except for
+ * the latest one.
+ *
+ * If one or many requests are sent during the [minimalTimeBetweenRequests] after a request has been
+ * handled then only the most recent one will be forwarded to the handler.
+ *
+ * Please note that due to platform limitations the effective time will not always match
+ * the exact expected value in milliseconds.
+ */
+@FlowPreview
+@ExperimentalTime
+@ExperimentalCoroutinesApi
+class StateChangeRegulator(
+    private val minimalTimeBetweenRequests: Duration,
+    private val requestHandler: (StateChangeRequest) -> Unit
+) {
+    private val bus: BroadcastChannel<StateChangeRequest> = ConflatedBroadcastChannel()
+    private val flow = bus.asFlow()
+        .flatMapConcat {
+            flow {
+                emit(it)
+                delay(minimalTimeBetweenRequests)
+            }
+        }
+
+    /**
+     * Posts a request to change state.
+     *
+     * Not all requests will lead to a state change since they will all go through regulation.
+     */
+    suspend fun requestStateChange(request: StateChangeRequest) {
+        bus.send(request)
+    }
+
+    /**
+     * Start regulating requests. To be called from a dedicated coroutine.
+     */
+    suspend fun start() {
+        flow.collect { request -> requestHandler(request) }
+    }
+}

--- a/lib/src/main/java/com/fabernovel/statefullayout/StateChangeRequest.kt
+++ b/lib/src/main/java/com/fabernovel/statefullayout/StateChangeRequest.kt
@@ -1,0 +1,8 @@
+package com.fabernovel.statefullayout
+
+import androidx.annotation.IdRes
+
+data class StateChangeRequest(
+    @IdRes val id: Int,
+    val showTransitions: Boolean
+)

--- a/test-app/src/test/java/com/fabernovel/statefullayout/test/unit/StateChangeRegulatorTest.kt
+++ b/test-app/src/test/java/com/fabernovel/statefullayout/test/unit/StateChangeRegulatorTest.kt
@@ -1,0 +1,68 @@
+package com.fabernovel.statefullayout.test.unit
+
+import com.fabernovel.statefullayout.StateChangeRegulator
+import com.fabernovel.statefullayout.StateChangeRequest
+import kotlinx.coroutines.*
+import org.junit.Assert
+import org.junit.Test
+import kotlin.time.ExperimentalTime
+import kotlin.time.milliseconds
+
+@ExperimentalCoroutinesApi
+@FlowPreview
+@ExperimentalTime
+class StateChangeRegulatorTest {
+    @Test
+    fun `should keep first requested state for at least minimalTimeBetweenRequests`() {
+        var latestReceivedRequest: StateChangeRequest? = null
+        val regulator = StateChangeRegulator(REGULATOR_PACE) { request ->
+            println("Received change request to $request at ${System.currentTimeMillis()}")
+            latestReceivedRequest = request
+        }
+
+        GlobalScope.launch { regulator.start() }
+
+        runBlocking {
+            regulator.changeStateTo(0)
+            delay(REGULATOR_PACE * 0.1)
+            regulator.changeStateTo(1)
+            regulator.changeStateTo(2)
+            regulator.changeStateTo(3)
+            delay(REGULATOR_PACE * 0.8)
+            println("Asserting at ${System.currentTimeMillis()} that state is still 0")
+            Assert.assertEquals(0, latestReceivedRequest?.id)
+        }
+    }
+
+    @Test
+    fun `should only keep most recent request in case of backpressure`() {
+        var latestReceivedRequest: StateChangeRequest? = null
+        val regulator = StateChangeRegulator(REGULATOR_PACE) { request ->
+            println("Received change request to $request at ${System.currentTimeMillis()}")
+            latestReceivedRequest = request
+        }
+
+        GlobalScope.launch { regulator.start() }
+
+        runBlocking {
+            regulator.changeStateTo(0)
+            delay(REGULATOR_PACE * 0.5)
+            regulator.changeStateTo(1)
+            regulator.changeStateTo(2)
+            delay(REGULATOR_PACE * 0.1)
+            regulator.changeStateTo(3)
+            delay(REGULATOR_PACE * 1.2)
+            println("Asserting at ${System.currentTimeMillis()} that state is now 3")
+            Assert.assertEquals(3, latestReceivedRequest?.id)
+        }
+    }
+
+    private suspend fun StateChangeRegulator.changeStateTo(stateId: Int) {
+        println("Requesting state change to $stateId at ${System.currentTimeMillis()}")
+        requestStateChange(StateChangeRequest(stateId, false))
+    }
+
+    companion object {
+        private val REGULATOR_PACE = 100.milliseconds
+    }
+}


### PR DESCRIPTION
Once kotlin experimental APIs are stable, we can put the regulator directly inside StatefulLayout and expose a proper API.

Meanwhile usage should be opted-in.

Fixes #25 